### PR TITLE
#52 add team and league models

### DIFF
--- a/SportsHub/SportsHub.Core/Models/League.cs
+++ b/SportsHub/SportsHub.Core/Models/League.cs
@@ -1,0 +1,21 @@
+﻿namespace SportsHub.Domain.Models
+{
+    public class League
+    {
+        public League()
+        {
+            Teams = new HashSet<Team>();
+            SubLeagues = new HashSet<SubLeague>();
+        }
+
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+
+        public int SportId { get; set; }
+        public virtual Sport Sport { get; set; }
+
+        public virtual ICollection<Team> Teams { get; set; }
+        public virtual ICollection<SubLeague> SubLeagues { get; set; }
+    }
+}

--- a/SportsHub/SportsHub.Core/Models/League.cs
+++ b/SportsHub/SportsHub.Core/Models/League.cs
@@ -2,12 +2,6 @@
 {
     public class League
     {
-        public League()
-        {
-            Teams = new HashSet<Team>();
-            SubLeagues = new HashSet<SubLeague>();
-        }
-
         public int Id { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }

--- a/SportsHub/SportsHub.Core/Models/Sport.cs
+++ b/SportsHub/SportsHub.Core/Models/Sport.cs
@@ -2,11 +2,6 @@
 {
     public class Sport
     {
-        public Sport()
-        {
-            Leagues = new HashSet<League>();
-        }
-
         public int Id { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }

--- a/SportsHub/SportsHub.Core/Models/Sport.cs
+++ b/SportsHub/SportsHub.Core/Models/Sport.cs
@@ -1,0 +1,15 @@
+﻿namespace SportsHub.Domain.Models
+{
+    public class Sport
+    {
+        public Sport()
+        {
+            Leagues = new HashSet<League>();
+        }
+
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public virtual ICollection<League> Leagues { get; set; }
+    }
+}

--- a/SportsHub/SportsHub.Core/Models/SubLeague.cs
+++ b/SportsHub/SportsHub.Core/Models/SubLeague.cs
@@ -1,0 +1,12 @@
+﻿namespace SportsHub.Domain.Models
+{
+    public class SubLeague
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+
+        public int LeagueId { get; set; }
+        public virtual League League { get; set; }
+    }
+}

--- a/SportsHub/SportsHub.Core/Models/Team.cs
+++ b/SportsHub/SportsHub.Core/Models/Team.cs
@@ -1,0 +1,12 @@
+﻿namespace SportsHub.Domain.Models
+{
+    public class Team
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+
+        public int LeagueId { get; set; }
+        public virtual League League { get; set; }
+    }
+}

--- a/SportsHub/SportsHub.DAL/Data/Configurations/ArticleEntityTypeConfiguration.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/ArticleEntityTypeConfiguration.cs
@@ -15,7 +15,7 @@ namespace SportsHub.DAL.Data.Configurations
 
             article.Property(x => x.Title)
                 .IsRequired(true)
-                .HasMaxLength(ConfigurationConstants.ArticleTitleMaxLength)
+                .HasMaxLength(ConfigurationConstants.ArticleConstants.ArticleTitleMaxLength)
                 .IsUnicode(true);
 
             article.Property(x => x.Content)

--- a/SportsHub/SportsHub.DAL/Data/Configurations/CategoryEntityTypeConfiguration.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/CategoryEntityTypeConfiguration.cs
@@ -11,12 +11,12 @@ namespace SportsHub.DAL.Data.Configurations
         {
             category.Property(x => x.Name)
                 .IsRequired(true)
-                .HasMaxLength(ConfigurationConstants.CategoryNameMaxLength)
+                .HasMaxLength(ConfigurationConstants.CategoryConstants.CategoryNameMaxLength)
                 .IsUnicode(true);
 
             category.Property(x => x.Description)
                 .IsRequired(false)
-                .HasMaxLength(ConfigurationConstants.CategoryDescriptionMaxLength)
+                .HasMaxLength(ConfigurationConstants.CategoryConstants.CategoryDescriptionMaxLength)
                 .IsUnicode(true);
 
             category.HasMany(x => x.Articles)

--- a/SportsHub/SportsHub.DAL/Data/Configurations/CommentEntityTypeConfiguration.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/CommentEntityTypeConfiguration.cs
@@ -11,7 +11,7 @@ namespace SportsHub.DAL.Data.Configurations
         {
             comment.Property(x => x.Content)
                 .IsRequired(true)
-                .HasMaxLength(ConfigurationConstants.CommentContentMaxLength)
+                .HasMaxLength(ConfigurationConstants.CommentConstants.CommentContentMaxLength)
                 .IsUnicode(true);
 
             comment.Property(x => x.PostedOn)

--- a/SportsHub/SportsHub.DAL/Data/Configurations/Constants/ConfigurationConstants.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/Constants/ConfigurationConstants.cs
@@ -2,6 +2,14 @@
 {
     public static class ConfigurationConstants
     {
+        public const int SportNameMaxLength = 50;
+        public const int SportDescriptionMaxLength = 250;
+        public const int LeagueNameMaxLength = 50;
+        public const int LeagueDescriptionMaxLength = 250;
+        public const int SubLeagueNameMaxLength = 50;
+        public const int SubLeagueDescriptionMaxLength = 250;
+        public const int TeamNameMaxLength = 50;
+        public const int TeamDescriptionMaxLength = 250;
         public const int ArticleTitleMaxLength = 100;
         public const int CategoryNameMaxLength = 50;
         public const int CategoryDescriptionMaxLength = 250;

--- a/SportsHub/SportsHub.DAL/Data/Configurations/Constants/ConfigurationConstants.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/Constants/ConfigurationConstants.cs
@@ -2,25 +2,65 @@
 {
     public static class ConfigurationConstants
     {
-        public const int SportNameMaxLength = 50;
-        public const int SportDescriptionMaxLength = 250;
-        public const int LeagueNameMaxLength = 50;
-        public const int LeagueDescriptionMaxLength = 250;
-        public const int SubLeagueNameMaxLength = 50;
-        public const int SubLeagueDescriptionMaxLength = 250;
-        public const int TeamNameMaxLength = 50;
-        public const int TeamDescriptionMaxLength = 250;
-        public const int ArticleTitleMaxLength = 100;
-        public const int CategoryNameMaxLength = 50;
-        public const int CategoryDescriptionMaxLength = 250;
-        public const int CommentContentMaxLength = 450;
-        public const int RoleNameMaxLength = 25;
-        public const int StateNameMaxLenth = 30;
-        public const int UserEmailMaxLenth = 50;
-        public const int UserUsernameMaxLenth = 50;
-        public const int UserDisplayNameMaxLenth = 50;
-        public const int UserFirstNamelMaxLenth = 50;
-        public const int UserLastNamelMaxLenth = 50;
-        public const int UserPasswordlMaxLenth = 75;
+
+        public static class SportConstants
+        {
+            public const int SportNameMaxLength = 50;
+            public const int SportDescriptionMaxLength = 250;
+        }
+
+        public static class LeagueConstants
+        {
+            public const int LeagueNameMaxLength = 50;
+            public const int LeagueDescriptionMaxLength = 250;
+        }
+
+        public static class SubLeagueConstants
+        {
+            public const int SubLeagueNameMaxLength = 50;
+            public const int SubLeagueDescriptionMaxLength = 250;
+        }
+
+        public static class TeamConstants
+        {
+            public const int TeamNameMaxLength = 50;
+            public const int TeamDescriptionMaxLength = 250;
+        }
+
+        public static class ArticleConstants
+        {
+            public const int ArticleTitleMaxLength = 100;
+        }
+
+        public static class CategoryConstants
+        {
+            public const int CategoryNameMaxLength = 50;
+            public const int CategoryDescriptionMaxLength = 250;
+        }
+
+        public static class CommentConstants
+        {
+            public const int CommentContentMaxLength = 450;
+        }
+
+        public static class RoleConstants
+        {
+            public const int RoleNameMaxLength = 25;
+        }
+
+        public static class StateConstants
+        {
+            public const int StateNameMaxLenth = 30;
+        }
+
+        public static class UserConstants
+        {
+            public const int UserEmailMaxLenth = 50;
+            public const int UserUsernameMaxLenth = 50;
+            public const int UserDisplayNameMaxLenth = 50;
+            public const int UserFirstNamelMaxLenth = 50;
+            public const int UserLastNamelMaxLenth = 50;
+            public const int UserPasswordlMaxLenth = 75;
+        }
     }
 }

--- a/SportsHub/SportsHub.DAL/Data/Configurations/LeagueEntityTypeConfiguration.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/LeagueEntityTypeConfiguration.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SportsHub.DAL.Data.Configurations.Constants;
+using SportsHub.Domain.Models;
+
+namespace SportsHub.DAL.Data.Configurations
+{
+    public class LeagueEntityTypeConfiguration : IEntityTypeConfiguration<League>
+    {
+        public void Configure(EntityTypeBuilder<League> league)
+        {
+            league.Property(x => x.Name)
+                .IsRequired(true)
+                .HasMaxLength(ConfigurationConstants.LeagueNameMaxLength)
+                .IsUnicode(true);
+
+            league.Property(x => x.Description)
+                .IsRequired(false)
+                .HasMaxLength(ConfigurationConstants.LeagueDescriptionMaxLength)
+                .IsUnicode(true);
+
+            league.HasMany(x => x.SubLeagues)
+                .WithOne(x => x.League)
+                .HasForeignKey(x => x.LeagueId);
+
+            league.HasMany(x => x.Teams)
+                .WithOne(x => x.League)
+                .HasForeignKey(x => x.LeagueId);
+
+            league.HasOne(x => x.Sport)
+                .WithMany(x => x.Leagues)
+                .HasForeignKey(x => x.SportId);
+        }
+    }
+}

--- a/SportsHub/SportsHub.DAL/Data/Configurations/LeagueEntityTypeConfiguration.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/LeagueEntityTypeConfiguration.cs
@@ -11,12 +11,16 @@ namespace SportsHub.DAL.Data.Configurations
         {
             league.Property(x => x.Name)
                 .IsRequired(true)
-                .HasMaxLength(ConfigurationConstants.LeagueNameMaxLength)
+                .HasMaxLength(ConfigurationConstants.LeagueConstants.LeagueNameMaxLength)
                 .IsUnicode(true);
+
+
+            league.HasIndex(x => x.Name)
+                .IsUnique();
 
             league.Property(x => x.Description)
                 .IsRequired(false)
-                .HasMaxLength(ConfigurationConstants.LeagueDescriptionMaxLength)
+                .HasMaxLength(ConfigurationConstants.LeagueConstants.LeagueDescriptionMaxLength)
                 .IsUnicode(true);
 
             league.HasMany(x => x.SubLeagues)

--- a/SportsHub/SportsHub.DAL/Data/Configurations/RoleEntityTypeConfiguration.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/RoleEntityTypeConfiguration.cs
@@ -11,7 +11,7 @@ namespace SportsHub.DAL.Data.Configurations
         {
             role.Property(x => x.Name)
                 .IsRequired(true)
-                .HasMaxLength(ConfigurationConstants.RoleNameMaxLength)
+                .HasMaxLength(ConfigurationConstants.RoleConstants.RoleNameMaxLength)
                 .IsUnicode(true);
 
             role.HasMany(x => x.Users)

--- a/SportsHub/SportsHub.DAL/Data/Configurations/SportEntityTypeConfiguration.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/SportEntityTypeConfiguration.cs
@@ -11,12 +11,15 @@ namespace SportsHub.DAL.Data.Configurations
         {
             sport.Property(x => x.Name)
                 .IsRequired(true)
-                .HasMaxLength(ConfigurationConstants.SportNameMaxLength)
+                .HasMaxLength(ConfigurationConstants.SportConstants.SportNameMaxLength)
                 .IsUnicode(true);
+
+            sport.HasIndex(x => x.Name)
+                .IsUnique();
 
             sport.Property(x => x.Description)
                 .IsRequired(false)
-                .HasMaxLength(ConfigurationConstants.SportDescriptionMaxLength)
+                .HasMaxLength(ConfigurationConstants.SportConstants.SportDescriptionMaxLength)
                 .IsUnicode(true);
 
             sport.HasMany(x => x.Leagues)

--- a/SportsHub/SportsHub.DAL/Data/Configurations/SportEntityTypeConfiguration.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/SportEntityTypeConfiguration.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SportsHub.DAL.Data.Configurations.Constants;
+using SportsHub.Domain.Models;
+
+namespace SportsHub.DAL.Data.Configurations
+{
+    public class SportEntityTypeConfiguration : IEntityTypeConfiguration<Sport>
+    {
+        public void Configure(EntityTypeBuilder<Sport> sport)
+        {
+            // TODO: CHANGE ALL CONSTANTS
+
+            sport.Property(x => x.Name)
+                .IsRequired(true)
+                .HasMaxLength(ConfigurationConstants.SportNameMaxLength)
+                .IsUnicode(true);
+
+            sport.Property(x => x.Description)
+                .IsRequired(false)
+                .HasMaxLength(ConfigurationConstants.SportDescriptionMaxLength)
+                .IsUnicode(true);
+
+            sport.HasMany(x => x.Leagues)
+                .WithOne(x => x.Sport)
+                .HasForeignKey(x => x.SportId);
+        }
+    }
+}

--- a/SportsHub/SportsHub.DAL/Data/Configurations/SportEntityTypeConfiguration.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/SportEntityTypeConfiguration.cs
@@ -9,8 +9,6 @@ namespace SportsHub.DAL.Data.Configurations
     {
         public void Configure(EntityTypeBuilder<Sport> sport)
         {
-            // TODO: CHANGE ALL CONSTANTS
-
             sport.Property(x => x.Name)
                 .IsRequired(true)
                 .HasMaxLength(ConfigurationConstants.SportNameMaxLength)

--- a/SportsHub/SportsHub.DAL/Data/Configurations/StateEntityTypeConfiguration.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/StateEntityTypeConfiguration.cs
@@ -11,7 +11,7 @@ namespace SportsHub.DAL.Data.Configurations
         {
             state.Property(x => x.Name)
                 .IsRequired(true)
-                .HasMaxLength(ConfigurationConstants.StateNameMaxLenth)
+                .HasMaxLength(ConfigurationConstants.StateConstants.StateNameMaxLenth)
                 .IsUnicode(true);
 
             state.HasMany(x => x.Articles)

--- a/SportsHub/SportsHub.DAL/Data/Configurations/SubLeagueEntityTypeConfiguration.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/SubLeagueEntityTypeConfiguration.cs
@@ -11,12 +11,15 @@ namespace SportsHub.DAL.Data.Configurations
         {
             subLeague.Property(x => x.Name)
                 .IsRequired(true)
-                .HasMaxLength(ConfigurationConstants.SubLeagueNameMaxLength)
+                .HasMaxLength(ConfigurationConstants.SubLeagueConstants.SubLeagueNameMaxLength)
                 .IsUnicode(true);
+
+            subLeague.HasIndex(x => x.Name)
+                .IsUnique();
 
             subLeague.Property(x => x.Description)
                 .IsRequired(false)
-                .HasMaxLength(ConfigurationConstants.SubLeagueDescriptionMaxLength)
+                .HasMaxLength(ConfigurationConstants.SubLeagueConstants.SubLeagueDescriptionMaxLength)
                 .IsUnicode(true);
 
             subLeague.HasOne(x => x.League)

--- a/SportsHub/SportsHub.DAL/Data/Configurations/SubLeagueEntityTypeConfiguration.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/SubLeagueEntityTypeConfiguration.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SportsHub.DAL.Data.Configurations.Constants;
+using SportsHub.Domain.Models;
+
+namespace SportsHub.DAL.Data.Configurations
+{
+    public class SubLeagueEntityTypeConfiguration : IEntityTypeConfiguration<SubLeague>
+    {
+        public void Configure(EntityTypeBuilder<SubLeague> subLeague)
+        {
+            subLeague.Property(x => x.Name)
+                .IsRequired(true)
+                .HasMaxLength(ConfigurationConstants.SubLeagueNameMaxLength)
+                .IsUnicode(true);
+
+            subLeague.Property(x => x.Description)
+                .IsRequired(false)
+                .HasMaxLength(ConfigurationConstants.SubLeagueDescriptionMaxLength)
+                .IsUnicode(true);
+
+            subLeague.HasOne(x => x.League)
+                .WithMany(x => x.SubLeagues)
+                .HasForeignKey(x => x.LeagueId);
+        }
+    }
+}

--- a/SportsHub/SportsHub.DAL/Data/Configurations/TeamEntityTypeConfiguration.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/TeamEntityTypeConfiguration.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SportsHub.DAL.Data.Configurations.Constants;
+using SportsHub.Domain.Models;
+
+namespace SportsHub.DAL.Data.Configurations
+{
+    public class TeamEntityTypeConfiguration : IEntityTypeConfiguration<Team>
+    {
+        public void Configure(EntityTypeBuilder<Team> team)
+        {
+            team.Property(x => x.Name)
+                .IsRequired(true)
+                .HasMaxLength(ConfigurationConstants.TeamNameMaxLength)
+                .IsUnicode(true);
+
+            team.Property(x => x.Description)
+                .IsRequired(false)
+                .HasMaxLength(ConfigurationConstants.TeamDescriptionMaxLength)
+                .IsUnicode(true);
+
+            team.HasOne(x => x.League)
+                .WithMany(x => x.Teams)
+                .HasForeignKey(x => x.LeagueId);
+        }
+    }
+}

--- a/SportsHub/SportsHub.DAL/Data/Configurations/TeamEntityTypeConfiguration.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/TeamEntityTypeConfiguration.cs
@@ -11,12 +11,16 @@ namespace SportsHub.DAL.Data.Configurations
         {
             team.Property(x => x.Name)
                 .IsRequired(true)
-                .HasMaxLength(ConfigurationConstants.TeamNameMaxLength)
+                .HasMaxLength(ConfigurationConstants.TeamConstants.TeamNameMaxLength)
                 .IsUnicode(true);
+
+
+            team.HasIndex(x => x.Name)
+                .IsUnique();
 
             team.Property(x => x.Description)
                 .IsRequired(false)
-                .HasMaxLength(ConfigurationConstants.TeamDescriptionMaxLength)
+                .HasMaxLength(ConfigurationConstants.TeamConstants.TeamDescriptionMaxLength)
                 .IsUnicode(true);
 
             team.HasOne(x => x.League)

--- a/SportsHub/SportsHub.DAL/Data/Configurations/UserEntityTypeConfiguration.cs
+++ b/SportsHub/SportsHub.DAL/Data/Configurations/UserEntityTypeConfiguration.cs
@@ -11,12 +11,12 @@ namespace SportsHub.DAL.Data.Configurations
         {
             user.Property(x => x.Email)
                 .IsRequired(true)
-                .HasMaxLength(ConfigurationConstants.UserEmailMaxLenth)
+                .HasMaxLength(ConfigurationConstants.UserConstants.UserEmailMaxLenth)
                 .IsUnicode(true);
 
             user.Property(x => x.Username)
                 .IsRequired(true)
-                .HasMaxLength(ConfigurationConstants.UserUsernameMaxLenth)
+                .HasMaxLength(ConfigurationConstants.UserConstants.UserUsernameMaxLenth)
                 .IsUnicode(true);
 
             user.HasIndex(x => x.Username)
@@ -24,22 +24,22 @@ namespace SportsHub.DAL.Data.Configurations
 
             user.Property(x => x.DisplayName)
                 .IsRequired(true)
-                .HasMaxLength(ConfigurationConstants.UserDisplayNameMaxLenth)
+                .HasMaxLength(ConfigurationConstants.UserConstants.UserDisplayNameMaxLenth)
                 .IsUnicode(true);
 
             user.Property(x => x.FirstName)
                 .IsRequired(true)
-                .HasMaxLength(ConfigurationConstants.UserFirstNamelMaxLenth)
+                .HasMaxLength(ConfigurationConstants.UserConstants.UserFirstNamelMaxLenth)
                 .IsUnicode(true);
 
             user.Property(x => x.LastName)
                 .IsRequired(true)
-                .HasMaxLength(ConfigurationConstants.UserLastNamelMaxLenth)
+                .HasMaxLength(ConfigurationConstants.UserConstants.UserLastNamelMaxLenth)
                 .IsUnicode(true);
 
             user.Property(x => x.Password)
                 .IsRequired(true)
-                .HasMaxLength(ConfigurationConstants.UserPasswordlMaxLenth)
+                .HasMaxLength(ConfigurationConstants.UserConstants.UserPasswordlMaxLenth)
                 .IsUnicode(true);
 
             user.Property(x => x.ProfilePicture)

--- a/SportsHub/SportsHub.DAL/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/SportsHub/SportsHub.DAL/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -34,7 +34,7 @@ namespace SportsHub.DAL.Migrations
 
                     b.HasIndex("AuthorsId");
 
-                    b.ToTable("ArticleUser");
+                    b.ToTable("ArticleUser", (string)null);
                 });
 
             modelBuilder.Entity("SportsHub.Domain.Models.Article", b =>
@@ -79,7 +79,7 @@ namespace SportsHub.DAL.Migrations
                     b.HasIndex("Title")
                         .IsUnique();
 
-                    b.ToTable("Articles");
+                    b.ToTable("Articles", (string)null);
                 });
 
             modelBuilder.Entity("SportsHub.Domain.Models.Category", b =>
@@ -103,7 +103,7 @@ namespace SportsHub.DAL.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("Categories");
+                    b.ToTable("Categories", (string)null);
                 });
 
             modelBuilder.Entity("SportsHub.Domain.Models.Comment", b =>
@@ -137,7 +137,7 @@ namespace SportsHub.DAL.Migrations
 
                     b.HasIndex("AuthorId");
 
-                    b.ToTable("Comments");
+                    b.ToTable("Comments", (string)null);
                 });
 
             modelBuilder.Entity("SportsHub.Domain.Models.Role", b =>
@@ -156,7 +156,7 @@ namespace SportsHub.DAL.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("Roles");
+                    b.ToTable("Roles", (string)null);
                 });
 
             modelBuilder.Entity("SportsHub.Domain.Models.State", b =>
@@ -175,7 +175,7 @@ namespace SportsHub.DAL.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("States");
+                    b.ToTable("States", (string)null);
                 });
 
             modelBuilder.Entity("SportsHub.Domain.Models.User", b =>
@@ -235,7 +235,7 @@ namespace SportsHub.DAL.Migrations
                     b.HasIndex("Username")
                         .IsUnique();
 
-                    b.ToTable("Users");
+                    b.ToTable("Users", (string)null);
                 });
 
             modelBuilder.Entity("ArticleUser", b =>

--- a/SportsHub/SportsHub.DAL/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/SportsHub/SportsHub.DAL/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -34,7 +34,7 @@ namespace SportsHub.DAL.Migrations
 
                     b.HasIndex("AuthorsId");
 
-                    b.ToTable("ArticleUser", (string)null);
+                    b.ToTable("ArticleUser");
                 });
 
             modelBuilder.Entity("SportsHub.Domain.Models.Article", b =>
@@ -79,7 +79,7 @@ namespace SportsHub.DAL.Migrations
                     b.HasIndex("Title")
                         .IsUnique();
 
-                    b.ToTable("Articles", (string)null);
+                    b.ToTable("Articles");
                 });
 
             modelBuilder.Entity("SportsHub.Domain.Models.Category", b =>
@@ -103,7 +103,7 @@ namespace SportsHub.DAL.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("Categories", (string)null);
+                    b.ToTable("Categories");
                 });
 
             modelBuilder.Entity("SportsHub.Domain.Models.Comment", b =>
@@ -137,7 +137,7 @@ namespace SportsHub.DAL.Migrations
 
                     b.HasIndex("AuthorId");
 
-                    b.ToTable("Comments", (string)null);
+                    b.ToTable("Comments");
                 });
 
             modelBuilder.Entity("SportsHub.Domain.Models.Role", b =>
@@ -156,7 +156,7 @@ namespace SportsHub.DAL.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("Roles", (string)null);
+                    b.ToTable("Roles");
                 });
 
             modelBuilder.Entity("SportsHub.Domain.Models.State", b =>
@@ -175,7 +175,7 @@ namespace SportsHub.DAL.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("States", (string)null);
+                    b.ToTable("States");
                 });
 
             modelBuilder.Entity("SportsHub.Domain.Models.User", b =>
@@ -235,7 +235,7 @@ namespace SportsHub.DAL.Migrations
                     b.HasIndex("Username")
                         .IsUnique();
 
-                    b.ToTable("Users", (string)null);
+                    b.ToTable("Users");
                 });
 
             modelBuilder.Entity("ArticleUser", b =>


### PR DESCRIPTION
This task is related to Issue #52 . The current models have the following connections:
One Sport -> Many Leagues.
One League -> Many Teams & SubLeagues.

Let me know if you want to change the current model or if something is wrong.